### PR TITLE
feat: Add email notification for backup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ This application is my production daily backup script and it will keep your last
 I want to add some fetures to this script with your help and idea:</br>
 
 - Add email part to sent notification if process goes fail (we can use and API or some linux package and send directly), I defined that as an issue and you can help to solve it.
+- **Email Notifications for Failures**:
+  - The script can now send an email notification if the backup process encounters an error.
+  - To enable this, configure the following variables in `config.sh`:
+    - `recipient_email="your_email@example.com"`: The email address to send failure alerts to.
+    - `sender_email="backup-script@yourdomain.com"`: The "From" address for the notification email. (Note: Your mail server might need configuration to allow sending from this address).
+    - `email_subject_failure="BACKUP FAILED"`: The subject line for the failure email.
+  - **Dependency**: This feature requires a command-line mail utility to be installed on your system, such as `mailutils` (which provides the `mail` command). You can typically install it using your system's package manager (e.g., `sudo apt install mailutils`).
 - You can share your idea!</br>
 </br>
 You can find me: Pooyan.azadparvar@gmail.com </br>

--- a/backup.sh
+++ b/backup.sh
@@ -31,7 +31,13 @@ perform_backup() {
             preserve_mid_month_backup "$backup_filename"
         else
             log "Error: Backup process failed."
-            exit 1
+            # Construct the email message
+            email_message="Backup process failed. Please check the log file for details: $log_file"
+            # Send the email
+            echo "$email_message" | mail -s "$email_subject_failure" -r "$sender_email" "$recipient_email"
+            # Log that an attempt was made to send a notification email
+            log "Attempted to send failure notification email to $recipient_email."
+            exit 1 # Keep the exit 1 to indicate failure
         fi
 
         # Rotate backups

--- a/config.sh
+++ b/config.sh
@@ -5,3 +5,8 @@ log_file="/mnt/log/backup_log_$(date +'%Y%m%d_%H%M%S').log" #your log folder
 backup_filename="backup_$(date +'%Y%m%d_%H%M%S').tar.gz"
 max_backups=5  # Maximum number of backups to keep
 compression_level=1  # Set the compression level (1-9) for tar
+
+# Email configuration for notifications
+recipient_email="your_email@example.com"
+sender_email="backup-notifications@yourdomain.com" # Optional: for the 'From' field, might require mail server configuration
+email_subject_failure="Backup FAILED"


### PR DESCRIPTION
This commit introduces email notifications for backup failures.

Key changes:
- Added `recipient_email`, `sender_email`, and `email_subject_failure` variables to `config.sh` to allow you to configure email notifications.
- Modified `backup.sh` to check the exit status of the backup process (`tar` command). If a failure is detected, an email is sent to the configured recipient.
- The `mail` command (from `mailutils` or similar) is used to send the notification.
- Updated `README.md` to document the new feature, including the necessary configuration variables and the dependency on a mail utility.